### PR TITLE
[Changelog CI] Add Changelog for Version 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 * [#30](https://github.com/Kavan-Dalwadi/canary-deployment/pull/30): Dev
 * [#31](https://github.com/Kavan-Dalwadi/canary-deployment/pull/31): Dev
 * [#38](https://github.com/Kavan-Dalwadi/canary-deployment/pull/38): Release 0.0.6
+* [#43](https://github.com/Kavan-Dalwadi/canary-deployment/pull/43): abc changes, version patch
+
+
+# Version: 0.1.2
+
+* [#28](https://github.com/Kavan-Dalwadi/canary-deployment/pull/28): scaled replica from 1 to 2
+* [#29](https://github.com/Kavan-Dalwadi/canary-deployment/pull/29): scaled replicas to 5
+* [#30](https://github.com/Kavan-Dalwadi/canary-deployment/pull/30): Dev
+* [#31](https://github.com/Kavan-Dalwadi/canary-deployment/pull/31): Dev
+* [#38](https://github.com/Kavan-Dalwadi/canary-deployment/pull/38): Release 0.0.6
 
 
 # Version: 0.1.1


### PR DESCRIPTION
# Version: 0.1.2

* [#28](https://github.com/Kavan-Dalwadi/canary-deployment/pull/28): scaled replica from 1 to 2
* [#29](https://github.com/Kavan-Dalwadi/canary-deployment/pull/29): scaled replicas to 5
* [#30](https://github.com/Kavan-Dalwadi/canary-deployment/pull/30): Dev
* [#31](https://github.com/Kavan-Dalwadi/canary-deployment/pull/31): Dev
* [#38](https://github.com/Kavan-Dalwadi/canary-deployment/pull/38): Release 0.0.6
* [#43](https://github.com/Kavan-Dalwadi/canary-deployment/pull/43): abc changes, version patch
